### PR TITLE
Update capture operator example in Elixir documentation

### DIFF
--- a/modules/ROOT/pages/elixir/operators/capture-operator.adoc
+++ b/modules/ROOT/pages/elixir/operators/capture-operator.adoc
@@ -32,11 +32,11 @@ You can also use the Capture operator to reference named functions from modules.
 
 [source,elixir]
 ----
-iex> len = &List.length/1
-&List.length/1
+iex> len = &length/1
+&:erlang.length/1
 iex> len.([1, 2, 3, 4, 5])
 5
 ----
 
-In the example above, `&List.length/1` captures the `length` function from the `List` module, which takes one argument (`/1`). This function is then assigned to the variable `len`.
+In the example above, `&length/1` captures the `length` function from the which takes one argument (`/1`). This function is then assigned to the variable `len`.
 


### PR DESCRIPTION
When capture and using `&List.length/1`, an error like the following image occurred, so i fixed it to capture the `length/1` function.

![srs](https://github.com/wintermeyer/elixir-phoenix-ash/assets/62772873/6e87310f-e12e-4170-9bbe-bcd6d39f01ec)

![srs2](https://github.com/wintermeyer/elixir-phoenix-ash/assets/62772873/07547eb5-da42-4cc7-abe1-181204997f8b)
