### PR TITLE
Minor errata

### DIFF
--- a/modules/ROOT/pages/elixir/control-structures/with-and-for.adoc
+++ b/modules/ROOT/pages/elixir/control-structures/with-and-for.adoc
@@ -49,7 +49,7 @@ In this example, `for` iterates over each number in the list `[1, 2, 3, 4, 5]`,
 squares each number (`num * num`), and collects the results into a new list. 
 This list is then assigned to the variable `squared_numbers`.
 
-You can also filter elements in a `for` comprehension using `when`:
+You can also filter elements in a `for` comprehension using a guard clause:
 
 [source,elixir]
 ----

--- a/modules/ROOT/pages/elixir/recursion.adoc
+++ b/modules/ROOT/pages/elixir/recursion.adoc
@@ -101,3 +101,4 @@ https://stackoverflow.com were your friends. They still are but ChatGPT and Gith
 
 During this book, we will work with recursions. So you'll get a better feeling for
 it.
+


### PR DESCRIPTION
Some minor errata fixes.

- Fix missing line break messing with the next section markdown header
- Replace `when` with "guard clause" for example that does not use a `when`

Great resource by the way, thanks!

<img width="1481" alt="Screenshot 2024-02-19 at 12 48 03" src="https://github.com/wintermeyer/elixir-phoenix-ash/assets/866604/51ebf837-f6be-4eea-9288-d2f2a818e45a">
