### PR TITLE
Correct output of phx.new --version

### DIFF
--- a/modules/ROOT/pages/phoenix/index.adoc
+++ b/modules/ROOT/pages/phoenix/index.adoc
@@ -23,7 +23,7 @@ installed.
 [source,bash]
 ----
 $ mix phx.new --version
-Phoenix v1.8.0-rc.3
+Phoenix installer v1.8.0-rc.3
 ----
 ====
 


### PR DESCRIPTION
As of 1.8.0-rc3, Phoenix reports its version name as 'Phoenix installer' rather than just 'Phoenix'.