### PR TITLE
Fix match-operator.adoc

### DIFF
--- a/modules/ROOT/pages/elixir/operators/match-operator.adoc
+++ b/modules/ROOT/pages/elixir/operators/match-operator.adoc
@@ -308,4 +308,4 @@ while pattern matching the first item to `first`.
 <2> With the list `cart2`, we pattern match the first item to `head`, ignoring
 the rest of the list by prefixing `_` to `tail`.
 
-NOTE: Using `_tail` instead of just `_` increases the readability of the code.
+NOTE: Using `{+_tail+}` instead of just `{+_+}` increases the readability of the code.

--- a/modules/ROOT/pages/elixir/operators/match-operator.adoc
+++ b/modules/ROOT/pages/elixir/operators/match-operator.adoc
@@ -308,4 +308,4 @@ while pattern matching the first item to `first`.
 <2> With the list `cart2`, we pattern match the first item to `head`, ignoring
 the rest of the list by prefixing `_` to `tail`.
 
-NOTE: Using `{+_tail+}` instead of just `{+_+}` increases the readability of the code.
+NOTE: Using `+_tail+` instead of just `+_+` increases the readability of the code.


### PR DESCRIPTION
The Note renders incorrectly currently, this PR fixes the same:

<img width="862" height="518" alt="image" src="https://github.com/user-attachments/assets/b1d8df34-38fd-4e79-b873-05659192870f" />

Ref: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#literals-and-source-code