### PR TITLE
Remove Stream.unzip/1 from stream.adoc since it does not exist in the standard library

### DIFF
--- a/modules/ROOT/pages/elixir/stream.adoc
+++ b/modules/ROOT/pages/elixir/stream.adoc
@@ -187,21 +187,3 @@ Stream.cycle([1, 2])
 
 More details can be found at the official link:https://hexdocs.pm/elixir/Stream.html#cycle/1[Elixir Stream.cycle/1 documentation].
 
-[[stream-unzip]]
-==== Stream.unzip/1
-indexterm:[Stream,Functions,unzip]
-
-The link:https://hexdocs.pm/elixir/Stream.html#unzip/1[`Stream.unzip/1`] function generates two new streams from a stream of tuples.
-
-[source,elixir]
-----
-list = [{1, "a"}, {2, "b"}, {3, "c"}]
-{left, right} = Stream.unzip(list)
-Enum.to_list(left)
-# => [1, 2, 3]
-Enum.to_list(right)
-# => ["a", "b", "c"]
-----
-
-More details can be found at the official link:https://hexdocs.pm/elixir/Stream.html#unzip/1[Elixir Stream.unzip/1 documentation].
-


### PR DESCRIPTION
Stream.unzip/1 does not exist in the standard library. I got the following error trying to follow the example:

```elixir
iex(1)> list = [{1, "a"}, {2, "b"}, {3, "c"}]
[{1, "a"}, {2, "b"}, {3, "c"}]
iex(2)> {left, right} = Stream.unzip(list)
** (UndefinedFunctionError) function Stream.unzip/1 is undefined or private. Did you mean:

      * uniq/1

    (elixir 1.18.4) Stream.unzip([{1, "a"}, {2, "b"}, {3, "c"}])
    iex:2: (file)
```

Also see the discussion here: https://groups.google.com/g/elixir-lang-core/c/xS_Us4_Hzg0